### PR TITLE
Fix iconv deprecation message

### DIFF
--- a/lib/vendor/puppet/external/pson/common.rb
+++ b/lib/vendor/puppet/external/pson/common.rb
@@ -321,6 +321,21 @@ module PSON
   rescue PSON::NestingError
     raise ArgumentError, "exceed depth limit"
   end
+
+
+  # Provide a smarter wrapper for changing string encoding that works with
+  # both Ruby 1.8 (iconv) and 1.9 (String#encode).  Thankfully they seem to
+  # have compatible input syntax, at least for the encodings we touch.
+  if String.method_defined?("encode")
+    def encode(to, from, string)
+      string.encode(to, from)
+    end
+  else
+    require 'iconv'
+    def encode(to, from, string)
+      Iconv.conv(to, from, string)
+    end
+  end
 end
 
 module ::Kernel

--- a/lib/vendor/puppet/external/pson/pure.rb
+++ b/lib/vendor/puppet/external/pson/pure.rb
@@ -3,68 +3,6 @@ require 'puppet/external/pson/pure/parser'
 require 'puppet/external/pson/pure/generator'
 
 module PSON
-  begin
-    require 'iconv'
-    # An iconv instance to convert from UTF8 to UTF16 Big Endian.
-    UTF16toUTF8 = Iconv.new('utf-8', 'utf-16be') # :nodoc:
-    # An iconv instance to convert from UTF16 Big Endian to UTF8.
-    UTF8toUTF16 = Iconv.new('utf-16be', 'utf-8') # :nodoc:
-    UTF8toUTF16.iconv('no bom')
-  rescue LoadError
-    # We actually don't care
-    Puppet.warning "iconv couldn't be loaded, which is required for UTF-8/UTF-16 conversions"
-  rescue Errno::EINVAL, Iconv::InvalidEncoding
-    # Iconv doesn't support big endian utf-16. Let's try to hack this manually
-    # into the converters.
-    begin
-      old_verbose, $VERBSOSE = $VERBOSE, nil
-      # An iconv instance to convert from UTF8 to UTF16 Big Endian.
-      UTF16toUTF8 = Iconv.new('utf-8', 'utf-16') # :nodoc:
-      # An iconv instance to convert from UTF16 Big Endian to UTF8.
-      UTF8toUTF16 = Iconv.new('utf-16', 'utf-8') # :nodoc:
-      UTF8toUTF16.iconv('no bom')
-      if UTF8toUTF16.iconv("\xe2\x82\xac") == "\xac\x20"
-        swapper = Class.new do
-          def initialize(iconv) # :nodoc:
-            @iconv = iconv
-          end
-
-          def iconv(string) # :nodoc:
-            result = @iconv.iconv(string)
-            PSON.swap!(result)
-          end
-        end
-        UTF8toUTF16 = swapper.new(UTF8toUTF16) # :nodoc:
-      end
-      if UTF16toUTF8.iconv("\xac\x20") == "\xe2\x82\xac"
-        swapper = Class.new do
-          def initialize(iconv) # :nodoc:
-            @iconv = iconv
-          end
-
-          def iconv(string) # :nodoc:
-            string = PSON.swap!(string.dup)
-            @iconv.iconv(string)
-          end
-        end
-        UTF16toUTF8 = swapper.new(UTF16toUTF8) # :nodoc:
-      end
-    rescue Errno::EINVAL, Iconv::InvalidEncoding
-      Puppet.warning "iconv doesn't seem to support UTF-8/UTF-16 conversions"
-    ensure
-      $VERBOSE = old_verbose
-    end
-  end
-
-  # Swap consecutive bytes of _string_ in place.
-  def self.swap!(string) # :nodoc:
-    0.upto(string.size / 2) do |i|
-      break unless string[2 * i + 1]
-      string[2 * i], string[2 * i + 1] = string[2 * i + 1], string[2 * i]
-    end
-    string
-  end
-
   # This module holds all the modules/classes that implement PSON's
   # functionality in pure ruby.
   module Pure

--- a/lib/vendor/puppet/external/pson/pure/generator.rb
+++ b/lib/vendor/puppet/external/pson/pure/generator.rb
@@ -45,7 +45,7 @@ module PSON
       string.force_encoding(Encoding::ASCII_8BIT)
       string.gsub!(/["\\\x0-\x1f]/) { MAP[$MATCH] }
       string
-    rescue Iconv::Failure => e
+    rescue => e
       raise GeneratorError, "Caught #{e.class}: #{e}"
     end
   else

--- a/lib/vendor/puppet/external/pson/pure/parser.rb
+++ b/lib/vendor/puppet/external/pson/pure/parser.rb
@@ -141,7 +141,7 @@ module PSON
                 bytes << c[6 * i + 2, 2].to_i(16) << c[6 * i + 4, 2].to_i(16)
                 i += 1
               end
-              PSON::UTF16toUTF8.iconv(bytes)
+              PSON.encode('utf-8', 'utf-16be', bytes)
             end
           end
           string.force_encoding(Encoding::UTF_8) if string.respond_to?(:force_encoding)
@@ -149,7 +149,7 @@ module PSON
         else
           UNPARSED
         end
-      rescue Iconv::Failure => e
+      rescue => e
         raise GeneratorError, "Caught #{e.class}: #{e}"
       end
 


### PR DESCRIPTION
```
/Users/pmorley/.rvm/gems/ruby-1.9.3-p194@puppet-modules/gems/puppet-parse-0.0.4/lib/vendor/puppet/external/pson/pure.rb:7:in `<module:PSON>': iconv will be deprecated in the future, use String#encode instead.
```

Looks like an issue with puppet 2.7.\* and they fixed it in 3.1.*:
https://github.com/puppetlabs/puppet/commit/eea1ef5a594c2c9a33cfafac899b1c4317dabc2a

I assume you don't want to fully upgrade the whole vendor/puppet folder, so I just pulled in the one change needed. What do you think?

BTW, awesome gem, exactly what I needed for an easy CI task for our puppet modules :) :+1:
