### PR TITLE
Basic addition for no arguments given

### DIFF
--- a/bin/puppet-parse
+++ b/bin/puppet-parse
@@ -4,6 +4,8 @@ $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), "..", "lib
 require 'puppet-parse'
 require 'yaml'
 
+abort 'puppet-parse: no arguments given ' if ARGV[0].nil?
+
 run = PuppetParse::Runner.new
 puts run.run(ARGV).to_yaml
 


### PR DESCRIPTION
A quick one so that if you do

``` shell
puppet-parse 
```

it exits with a little message and a status of false.

Larger refactor underway so you can do `puppet-parse .` or `puppet-parse fo/bar` is underway :+1: 
