### PR TITLE
Expose the resource type in the inspection

### DIFF
--- a/lib/puppet-parse/parser.rb
+++ b/lib/puppet-parse/parser.rb
@@ -34,6 +34,11 @@ class PuppetParse
       @object.name if (defined? @object.class.name)
     end
 
+    # Read type from parsed object, returns symbol containing type (hostclass, definition, node)
+    def type
+      @object.type if (defined? @object.type)
+    end
+
     # Read RDOC contents from parsed object, returns hash of paragraph headings
     # and the following paragraph contents
     #(i.e. parameter and parameter documentation)

--- a/lib/puppet-parse/runner.rb
+++ b/lib/puppet-parse/runner.rb
@@ -13,7 +13,8 @@ class PuppetParse
         result           = {
           content.klass  => {
             'parameters' => parameters,
-            'docs'       => content.docs
+            'docs'       => content.docs,
+            'type'       => content.type.to_s,
           }
         }
         output = output.merge(result)


### PR DESCRIPTION
This patch adds the resource type to the output (hostclass, definition, node).

```
  "java::oracle": 
    parameters: 
      ensure: present
      version: "8"
      java_se: jdk
      oracle_url: "http://download.oracle.com/otn-pub/java/jdk/"
    docs: {}
    type: definition
  "java::params": 
    parameters: {}
    docs: {}
    type: hostclass
```
